### PR TITLE
Fix for broken CanCraft hook

### DIFF
--- a/resources/Hurtworld.opj
+++ b/resources/Hurtworld.opj
@@ -26,7 +26,7 @@
                 "System.String"
               ]
             },
-            "MSILHash": "v/ykGl+kfAFzpRCtdfErjDwNujuKBSHBRFzaXb1Q550=",
+            "MSILHash": "VTQAuuYpcB/JD/lzO/IdRVgnosw9cfqL0ytNRKLXsyc=",
             "BaseHookName": null,
             "HookCategory": "Server"
           }
@@ -300,7 +300,7 @@
                 "System.String"
               ]
             },
-            "MSILHash": "v/ykGl+kfAFzpRCtdfErjDwNujuKBSHBRFzaXb1Q550=",
+            "MSILHash": "VTQAuuYpcB/JD/lzO/IdRVgnosw9cfqL0ytNRKLXsyc=",
             "BaseHookName": "IOnServerCommand [internal]",
             "HookCategory": "_Patches"
           }
@@ -949,7 +949,7 @@
             "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "this.networkView.owner, a0",
+            "ArgumentString": "this, a0, a1",
             "HookTypeName": "Simple",
             "Name": "ICanCraft [internal]",
             "HookName": "ICanCraft",
@@ -2921,6 +2921,35 @@
             "BaseHookName": "OnItemMutatorApplied",
             "HookCategory": "Item"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 6,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a3.sender",
+            "HookTypeName": "Simple",
+            "Name": "ICanCraftInitialize [internal]",
+            "HookName": "ICanCraftInitialize",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Crafter",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPCBeginCraftingServer",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Byte",
+                "System.Int32",
+                "System.Int32",
+                "uLink.NetworkMessageInfo"
+              ]
+            },
+            "MSILHash": "LsysxKFOGEWaCv9jbN76mMADbgU9+YahBL96aihiRfI=",
+            "BaseHookName": null,
+            "HookCategory": null
+          }
         }
       ],
       "Modifiers": [
@@ -3210,6 +3239,13 @@
           "AssemblyName": "Assembly-CSharp.dll",
           "TypeName": "StandardEntityFluidEffect",
           "FieldType": "Assembly-CSharp|EntityStats",
+          "Flagged": false
+        },
+        {
+          "Name": "NetworkPlayer",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "Crafter",
+          "FieldType": "uLink|uLink.NetworkPlayer",
           "Flagged": false
         }
       ]

--- a/resources/Hurtworld.opj
+++ b/resources/Hurtworld.opj
@@ -2948,7 +2948,7 @@
             },
             "MSILHash": "LsysxKFOGEWaCv9jbN76mMADbgU9+YahBL96aihiRfI=",
             "BaseHookName": null,
-            "HookCategory": null
+            "HookCategory": "Player"
           }
         }
       ],

--- a/src/HurtworldHooks.cs
+++ b/src/HurtworldHooks.cs
@@ -41,16 +41,27 @@ namespace Oxide.Game.Hurtworld
         #region Player Hooks
 
         /// <summary>
+        /// Called when the player craft attempt is initialized
+        /// </summary>
+        /// <param name="crafter"></param>
+        /// <param name="networkPlayer"></param>
+        [HookMethod("ICanCraftInitialize")]
+        private void ICanCraftInitialize(Crafter crafter, uLink.NetworkPlayer networkPlayer)
+        {
+            crafter.NetworkPlayer = networkPlayer;
+        }
+
+        /// <summary>
         /// Called when the player is attempting to craft
         /// </summary>
         /// <param name="netPlayer"></param>
         /// <param name="recipe"></param>
         /// <returns></returns>
         [HookMethod("ICanCraft")]
-        private object ICanCraft(NetworkPlayer netPlayer, ICraftable recipe)
+        private object ICanCraft(Crafter crafter, ICraftable recipe, int count)
         {
-            PlayerSession session = Player.Find(netPlayer);
-            return Interface.CallHook("CanCraft", session, recipe);
+            PlayerSession session = Player.Find(crafter.NetworkPlayer);
+            return Interface.CallHook("CanCraft", crafter, session, recipe, count);
         }
 
         /// <summary>
@@ -303,6 +314,7 @@ namespace Oxide.Game.Hurtworld
         /// Called when an entity effect is initialized
         /// </summary>
         /// <param name="effect"></param>
+        /// <param name="stats"></param>
         [HookMethod("IOnEntityEffectInitialize")]
         private void IOnEntityEffectInitialize(StandardEntityFluidEffect effect, EntityStats stats)
         {


### PR DESCRIPTION
### Fix for the broken CanCraft hook
- `PlayerSession` is now fixed (used to be `null`)
- `Crafter` added to determine what kind of crafter is used
- `int count` added to know the amount that is being crafted.
```cs
private object CanCraft(Crafter crafter, PlayerSession session, ICraftable recipe, int count)
{
   Puts("CanCraft works!");
   return null;
}
```

_\+ some hash changes_
_\+ added missing param in method sumary of `IOnEntityEffectInitialize`_