### PR TITLE
Added OnTownEventBroadcast hook

### DIFF
--- a/resources/Hurtworld.opj
+++ b/resources/Hurtworld.opj
@@ -26,7 +26,7 @@
                 "System.String"
               ]
             },
-            "MSILHash": "v/ykGl+kfAFzpRCtdfErjDwNujuKBSHBRFzaXb1Q550=",
+            "MSILHash": "VTQAuuYpcB/JD/lzO/IdRVgnosw9cfqL0ytNRKLXsyc=",
             "BaseHookName": null,
             "HookCategory": "Server"
           }
@@ -300,7 +300,7 @@
                 "System.String"
               ]
             },
-            "MSILHash": "v/ykGl+kfAFzpRCtdfErjDwNujuKBSHBRFzaXb1Q550=",
+            "MSILHash": "VTQAuuYpcB/JD/lzO/IdRVgnosw9cfqL0ytNRKLXsyc=",
             "BaseHookName": "IOnServerCommand [internal]",
             "HookCategory": "_Patches"
           }
@@ -2920,6 +2920,53 @@
             "MSILHash": "B1KjdiKWSc4FGvqp8ePg8RBD1uwxelP38Ta+9J7N6v4=",
             "BaseHookName": "OnItemMutatorApplied",
             "HookCategory": "Item"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 14,
+            "RemoveCount": 11,
+            "Instructions": [],
+            "HookTypeName": "Modify",
+            "Name": "OnTownEventBroadcast [patch]",
+            "HookName": "OnTownEventBroadcast [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseTownEvent",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Activate",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "7DriMjLwKa5p7fHAHpFqKHc1BktY3vrEV2UwgAbkkhY=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 14,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "IOnTownEventBroadcast [internal]",
+            "HookName": "IOnTownEventBroadcast",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseTownEvent",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Activate",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "7DriMjLwKa5p7fHAHpFqKHc1BktY3vrEV2UwgAbkkhY=",
+            "BaseHookName": "OnTownEventBroadcast [patch]",
+            "HookCategory": "Events"
           }
         }
       ],

--- a/src/HurtworldHooks.cs
+++ b/src/HurtworldHooks.cs
@@ -38,6 +38,26 @@ namespace Oxide.Game.Hurtworld
 
         #endregion Clan Hooks
 
+        #region Event Hooks
+        /// <summary>
+        /// Called when town event message is broadcasted to chat
+        /// </summary>
+        /// <param name="townEvent"></param>
+        /// <param name="name"></param>
+        [HookMethod("IOnTownEventBroadcast")]
+        private void IOnTownEventBroadcast(BaseTownEvent townEvent, string name)
+        {
+            object shouldBroadcast = Interface.CallHook("OnTownEventBroadcast", townEvent, name);
+            if (shouldBroadcast == null)
+            {
+                Singleton<ChatManagerServer>.Instance.SendChatMessage((IChatMessage)new LocalizedChatMessage(Color.yellow, "UI/Chat/TownEventStartFormat", new string[1]
+                {
+                    name
+                }));
+            }
+        }
+        #endregion Event Hooks
+
         #region Player Hooks
 
         /// <summary>


### PR DESCRIPTION
### Added OnTownEventBroadcast hook
Hook gets called when the game send the default town event message to chat.

```cs
object OnTownEventBroadcast(BaseTownEvent townEvent, string title)
{
    Puts("OnTownEventBroadcast works!");
    return null;
}
```